### PR TITLE
Possible out of memory fix when building Gatsby JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@wordpress/block-library": "^8.8.0",
     "bootstrap": "^5.2.3",
     "chokidar": "^3.5.3",
+    "cross-env": "^7.0.3",
     "framer-motion": "^10.12.4",
     "gatsby": "^5.9.0",
     "gatsby-plugin-image": "^3.9.0",
@@ -52,7 +53,7 @@
   ],
   "license": "0BSD",
   "scripts": {
-    "build": "gatsby build",
+    "build": "cross-env GATSBY_CPU_COUNT=2 NODE_OPTIONS=--max_old_space_size=4096 gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,css}\"",
     "start": "gatsby develop",

--- a/src/components/page/Banner/Banner.js
+++ b/src/components/page/Banner/Banner.js
@@ -3,7 +3,7 @@ import styled from "styled-components"
 import { Container, Actions, HeroBannerPadding } from "../../layoutComponents"
 import { ButtonPrimary, AnchorInline } from "../../buttons"
 import Breadcrumb from "../../Breadcrumb/Breadcrumb"
-import { StaticImage } from "gatsby-plugin-image"
+import { StaticImage, getImage, getSrc } from "gatsby-plugin-image"
 
 const BannerGrid = styled.div`
   display: grid;
@@ -19,8 +19,8 @@ const Wrapper = styled.div`
   grid-row: 1 / -1;
   grid-column: 1 / -1;
   z-index: 1;
-  // background: ${props => `url(${props.img})`}, rgba(0, 0, 0, 0.4);
-  background: url("../../../images/hero.jpg")), rgba(0, 0, 0, 0.4);
+  background: ${props => `url(${props.img})`}, rgba(0, 0, 0, 0.4);
+  //background: url("../../../images/hero.jpg")), rgba(0, 0, 0, 0.4);
   background-blend-mode: overlay;
   background-position: center;
   background-size: cover;
@@ -62,7 +62,7 @@ export default function Banner({ title, subheader, description, image }) {
     <div>
       <HeroBannerPadding />
       <BannerGrid>
-        <Wrapper img={image.localFile.childImageSharp.fluid.src}>
+        <Wrapper img={getSrc(image)}>
           <Container className="spacing">
             <Text className="spacing">
               <div className="">
@@ -80,5 +80,5 @@ export default function Banner({ title, subheader, description, image }) {
         </BannerBottomText>
       </BannerGrid>
     </div>
-  )
+  );
 }

--- a/src/components/page/ImageLeft/ImageLeft.js
+++ b/src/components/page/ImageLeft/ImageLeft.js
@@ -1,4 +1,4 @@
-import { GatsbyImage, StaticImage } from "gatsby-plugin-image"
+import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import React from "react"
 import styled from "styled-components"
 import { Container, Section, FlexMobileOpp } from "../../layoutComponents"
@@ -13,16 +13,22 @@ const StyledImg = styled(GatsbyImage)`
 `
 
 export default function ImageLeft({ subheader, title, body, image }) {
+  const img = getImage(image)
   return (
     <Section>
       <Container>
         <FlexMobileOpp>
-          <StaticImage src="../../../images/ph.jpg" className="stretch" />
-          {/* <StyledImg
+          {/*<StaticImage src="../../../images/ph.jpg" className="stretch" />
+          <StyledImg
             image={image.localFile.childImageSharp.gatsbyImageData}
             alt={image.altText}
             className="stretch"
           /> */}
+          <StyledImg
+            image={img}
+            alt=""
+            className="stretch"
+          />
           <Text className="spacing">
             <div>
               <p className="subheader accent">{subheader}</p>

--- a/src/components/page/ImageRight/ImageRight.js
+++ b/src/components/page/ImageRight/ImageRight.js
@@ -1,4 +1,4 @@
-import { GatsbyImage } from "gatsby-plugin-image"
+import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import React from "react"
 import styled from "styled-components"
 import { Container, Section, Flex } from "../../layoutComponents"
@@ -14,6 +14,7 @@ const StyledImg = styled(GatsbyImage)`
 `
 
 export default function ImageRight({ subheader, title, body, image }) {
+  const img = getImage(image)
   return (
     <Section>
       <Container>
@@ -38,7 +39,12 @@ export default function ImageRight({ subheader, title, body, image }) {
             alt={image.altText}
             className="stretch"
           /> */}
-          <StaticImage src="../../../images/ph.jpg" className="stretch" />
+          {/*<StaticImage src="../../../images/ph.jpg" className="stretch" /> */}
+          <StyledImg
+            image={img}
+            alt=""
+            className="stretch"
+          />
         </Flex>
       </Container>
     </Section>

--- a/src/fragments/components.js
+++ b/src/fragments/components.js
@@ -1,36 +1,24 @@
 
-    import { graphql } from 'gatsby'
+import { graphql } from 'gatsby'
   
-    export const componentFragments = graphql`
-       
- 
-      fragment Page_Badges on WpPage_Pagecomponents_PageComponents_Badges {
-        
-      title
-    
+export const componentFragments = graphql`fragment Page_Badges on WpPage_Pagecomponents_PageComponents_Badges {
+  title
+}
+
+fragment Page_Banner on WpPage_Pagecomponents_PageComponents_Banner {
+  title
+  description
+  subheader
+  image {
+    localFile {
+      childImageSharp {
+        gatsbyImageData(placeholder: BLURRED, layout: FULL_WIDTH)
       }
-     
- 
-      fragment Page_Banner on WpPage_Pagecomponents_PageComponents_Banner {
-        
-        title
-        description
-        subheader
-        image {
-          localFile {
-            childImageSharp {
-              fluid {
-                src
-              }
-            }
-          }
-        }
-      
-      }
-     
- 
-      fragment Page_Benefits1 on WpPage_Pagecomponents_PageComponents_Benefits1 {
-        
+    }
+  }
+}
+
+fragment Page_Benefits1 on WpPage_Pagecomponents_PageComponents_Benefits1 {
   subheader
   title
   benefitContent {
@@ -45,32 +33,26 @@
       }
     }
   }
-  
-      }
-     
- 
-      fragment Page_Carousel on WpPage_Pagecomponents_PageComponents_Carousel {
-        
-    subheader
+}
+
+fragment Page_Carousel on WpPage_Pagecomponents_PageComponents_Carousel {
+  subheader
+  title
+  carouselContent {
     title
-    carouselContent {
-      title
-      description
-      image {
-        altText
-        localFile {
-          childImageSharp {
-            gatsbyImageData
-          }
+    description
+    image {
+      altText
+      localFile {
+        childImageSharp {
+          gatsbyImageData
         }
       }
     }
-  
-      }
-     
- 
-      fragment Page_ComponentA on WpPage_Pagecomponents_PageComponents_ComponentA {
-        
+  }
+}
+
+fragment Page_ComponentA on WpPage_Pagecomponents_PageComponents_ComponentA {
   body
   subheader
   title
@@ -87,62 +69,50 @@
       }
     }
   }
-    
-      }
-     
- 
-      fragment Page_ComponentB on WpPage_Pagecomponents_PageComponents_ComponentB {
-        
-    body
-    subheader
+}
+
+fragment Page_ComponentB on WpPage_Pagecomponents_PageComponents_ComponentB {
+  body
+  subheader
+  title
+  componentItems {
     title
-    componentItems {
-      title
-      text
-      button
-      image {
-        altText
-        localFile {
-          childImageSharp {
-            gatsbyImageData
-          }
+    text
+    button
+    image {
+      altText
+      localFile {
+        childImageSharp {
+          gatsbyImageData
         }
       }
     }
-      
+  }
+}
+
+fragment Page_ComponentC on WpPage_Pagecomponents_PageComponents_ComponentC {
+  subheader
+  title
+  body
+  image {
+    altText
+    localFile {
+      childImageSharp {
+        gatsbyImageData
       }
-     
- 
-      fragment Page_ComponentC on WpPage_Pagecomponents_PageComponents_ComponentC {
-        
-        subheader
-        title
-        body
-        image {
-            altText
-            localFile {
-                childImageSharp {
-                    gatsbyImageData
-                }
-            }
-        }
-    
-      }
-     
- 
-      fragment Page_ComponentD on WpPage_Pagecomponents_PageComponents_ComponentD {
-        
-    subheader
-    title
-    content {
-        text
     }
-  
-      }
-     
- 
-      fragment Page_ComponentE on WpPage_Pagecomponents_PageComponents_ComponentE {
-        
+  }
+}
+
+fragment Page_ComponentD on WpPage_Pagecomponents_PageComponents_ComponentD {
+  subheader
+  title
+  content {
+    text
+  }
+}
+
+fragment Page_ComponentE on WpPage_Pagecomponents_PageComponents_ComponentE {
   subheader
   title
   content {
@@ -157,12 +127,9 @@
       }
     }
   }
-    
-      }
-     
- 
-      fragment Page_Cta1 on WpPage_Pagecomponents_PageComponents_Cta1 {
-        
+}
+
+fragment Page_Cta1 on WpPage_Pagecomponents_PageComponents_Cta1 {
   body
   title
   subheader
@@ -174,213 +141,150 @@
       }
     }
   }
-    
+}
+
+fragment Page_Cta2 on WpPage_Pagecomponents_PageComponents_Cta2 {
+  title
+  body
+  image {
+    altText
+    localFile {
+      childImageSharp {
+        gatsbyImageData
       }
-     
- 
-      fragment Page_Cta2 on WpPage_Pagecomponents_PageComponents_Cta2 {
-        
-      title
-      body
-      image {
-          altText
-          localFile {
-              childImageSharp {
-                  gatsbyImageData
-              }
-          }
-      }
-      
-      }
-     
- 
-      fragment Page_Ebook on WpPage_Pagecomponents_PageComponents_Ebook {
-        
-    title
-    image {
-        altText
-        localFile {
-            childImageSharp {
-                gatsbyImageData
-            }
-        }
     }
-    
+  }
+}
+
+fragment Page_Ebook on WpPage_Pagecomponents_PageComponents_Ebook {
+  title
+  image {
+    altText
+    localFile {
+      childImageSharp {
+        gatsbyImageData
       }
-     
- 
-      fragment Page_Faq on WpPage_Pagecomponents_PageComponents_Faq {
-        
+    }
+  }
+}
+
+fragment Page_Faq on WpPage_Pagecomponents_PageComponents_Faq {
   title
   body
   questions {
     question
     answer
   }
-  
+}
+
+fragment Page_HeroSlider on WpPage_Pagecomponents_PageComponents_HeroSlider {
+  title
+}
+
+fragment Page_ImageGallery on WpPage_Pagecomponents_PageComponents_ImageGallery {
+  body
+  title
+  subheader
+  imageGallery {
+    altText
+    localFile {
+      childImageSharp {
+        gatsbyImageData
       }
-     
- 
-      fragment Page_HeroSlider on WpPage_Pagecomponents_PageComponents_HeroSlider {
-        
-    title
-      
+    }
+  }
+}
+
+fragment Page_ImageLeft on WpPage_Pagecomponents_PageComponents_ImageLeft {
+  subheader
+  title
+  body
+  image {
+    altText
+    localFile {
+      childImageSharp {
+        gatsbyImageData
       }
-     
- 
-      fragment Page_ImageGallery on WpPage_Pagecomponents_PageComponents_ImageGallery {
-        
-            body
-            title
-            subheader
-            imageGallery {
-              altText
-              localFile {
-                childImageSharp {
-                  gatsbyImageData
-                }
-              }
-            }
-    
+    }
+  }
+}
+
+fragment Page_ImageLeftDark on WpPage_Pagecomponents_PageComponents_ImageLeftDark {
+  subheader
+  title
+  body
+  image {
+    altText
+    localFile {
+      childImageSharp {
+        gatsbyImageData
       }
-     
- 
-      fragment Page_ImageLeft on WpPage_Pagecomponents_PageComponents_ImageLeft {
-        
-          subheader
-          title
-          body
-          image {
-              altText
-              localFile {
-                childImageSharp {
-                  gatsbyImageData
-                }
-              }
-            }
-      
+    }
+  }
+}
+
+fragment Page_ImageRight on WpPage_Pagecomponents_PageComponents_ImageRight {
+  subheader
+  title
+  body
+  image {
+    altText
+    localFile {
+      childImageSharp {
+        gatsbyImageData
       }
-     
- 
-      fragment Page_ImageLeftDark on WpPage_Pagecomponents_PageComponents_ImageLeftDark {
-        
-            subheader
-            title
-            body
-            image {
-                altText
-                localFile {
-                  childImageSharp {
-                    gatsbyImageData
-                  }
-                }
-              }
-        
-      }
-     
- 
-      fragment Page_ImageRight on WpPage_Pagecomponents_PageComponents_ImageRight {
-        
-        subheader
-        title
-        body
-        image {
-            altText
-            localFile {
-              childImageSharp {
-                gatsbyImageData
-              }
-            }
-          }
-    
-      }
-     
- 
-      fragment Page_ImageSlider on WpPage_Pagecomponents_PageComponents_ImageSlider {
-        
-    subheader
-    title
-    body
-  
-      }
-     
- 
-      fragment Page_ProcessA on WpPage_Pagecomponents_PageComponents_ProcessA {
-        
+    }
+  }
+}
+
+fragment Page_ImageSlider on WpPage_Pagecomponents_PageComponents_ImageSlider {
+  subheader
+  title
+  body
+}
+
+fragment Page_ProcessA on WpPage_Pagecomponents_PageComponents_ProcessA {
   title
   description
   processContent {
     number
     processDescription
   }
-  
-      }
-     
- 
-      fragment Page_ProcessB on WpPage_Pagecomponents_PageComponents_ProcessB {
-        
+}
+
+fragment Page_ProcessB on WpPage_Pagecomponents_PageComponents_ProcessB {
+  title
+  subheader
+  body
+  processContent {
+    number
     title
-    subheader
     body
-    processContent {
-      number
-      title
-      body
-    }
-    
-      }
-     
- 
-      fragment Page_RelatedServices on WpPage_Pagecomponents_PageComponents_RelatedServices {
-        
-    serviceContent {
-      title
-      link
-      image {
-        altText
-        localFile {
-          childImageSharp {
-            gatsbyImageData
-          }
+  }
+}
+
+fragment Page_RelatedServices on WpPage_Pagecomponents_PageComponents_RelatedServices {
+  serviceContent {
+    title
+    link
+    image {
+      altText
+      localFile {
+        childImageSharp {
+          gatsbyImageData
         }
       }
     }
-      
-      }
-     
- 
-      fragment Page_ServiceArea on WpPage_Pagecomponents_PageComponents_ServiceArea {
-        
-    title
-    content1
-    content2
-    
-      }
-     
- 
-      fragment Page_TabsSide on WpPage_Pagecomponents_PageComponents_TabsSide {
-        
-    title
-    tabsContent {
-      tabTitle
-      tabList
-      tabLabel
-      tabBody
-      tabImage {
-        altText
-        localFile {
-          childImageSharp {
-            gatsbyImageData
-          }
-        }
-      }
-    }
-    
-      }
-     
- 
-      fragment Page_TabsTop on WpPage_Pagecomponents_PageComponents_TabsTop {
-        
+  }
+}
+
+fragment Page_ServiceArea on WpPage_Pagecomponents_PageComponents_ServiceArea {
+  title
+  content1
+  content2
+}
+
+fragment Page_TabsSide on WpPage_Pagecomponents_PageComponents_TabsSide {
   title
   tabsContent {
     tabTitle
@@ -396,26 +300,36 @@
       }
     }
   }
-  
+}
+
+fragment Page_TabsTop on WpPage_Pagecomponents_PageComponents_TabsTop {
+  title
+  tabsContent {
+    tabTitle
+    tabList
+    tabLabel
+    tabBody
+    tabImage {
+      altText
+      localFile {
+        childImageSharp {
+          gatsbyImageData
+        }
       }
-     
- 
-      fragment Page_Testimonial on WpPage_Pagecomponents_PageComponents_Testimonial {
-        
-    title
-    testimonials {
-        testimonialBody
-        testimonialTitle
-        testimonialName
     }
-    
-      }
-     
- 
-      fragment Page_Text on WpPage_Pagecomponents_PageComponents_Text {
-        
-      text
-      }
-    
-    `
+  }
+}
+
+fragment Page_Testimonial on WpPage_Pagecomponents_PageComponents_Testimonial {
+  title
+  testimonials {
+    testimonialBody
+    testimonialTitle
+    testimonialName
+  }
+}
+
+fragment Page_Text on WpPage_Pagecomponents_PageComponents_Text {
+  text
+}`
     

--- a/src/templates/blog-post-archive.js
+++ b/src/templates/blog-post-archive.js
@@ -243,11 +243,7 @@ export default BlogIndex
 
 export const pageQuery = graphql`
   query WordPressPostArchive($offset: Int!, $postsPerPage: Int!) {
-    allWpPost(
-      sort: { fields: [date], order: DESC }
-      limit: $postsPerPage
-      skip: $offset
-    ) {
+    allWpPost(sort: {date: DESC}, limit: $postsPerPage, skip: $offset) {
       nodes {
         excerpt
         uri

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -161,7 +161,7 @@ const NewsTemplate = pageProps => {
           <HeroBannerPadding />
           <BannerGrid>
             <BannerWrapper
-              img={data.bannerImage.localFile.childImageSharp.fluid.src}
+              img={data.bannerImage.localFile.childImageSharp.gatsbyImageData.src}
             >
               <Container className="spacing">
                 <BannerText className="spacing">
@@ -267,30 +267,26 @@ const NewsTemplate = pageProps => {
         </Container>
       </Section>
     </Layout>
-  )
+  );
 }
 
 export default NewsTemplate
 
-export const query = graphql`
-  query PostQuery($id: String!) {
-    wpPost(id: { eq: $id }) {
-      title
-      date
-      post {
-        bannerImage {
-          localFile {
-            childImageSharp {
-              fluid {
-                src
-              }
-            }
+export const query = graphql`query PostQuery($id: String!) {
+  wpPost(id: {eq: $id}) {
+    title
+    date
+    post {
+      bannerImage {
+        localFile {
+          childImageSharp {
+            gatsbyImageData(placeholder: BLURRED, layout: FULL_WIDTH)
           }
         }
-        title
-        excerpt
-        content
       }
+      title
+      excerpt
+      content
     }
   }
-`
+}`


### PR DESCRIPTION
Possible out of memory fix when building Gatsby JS with the Wordpress project.

Adding GATSBY_CPU_COUNT NODE_OPTIONS env variables to set Node's heap memory in check.
Fixing `gatsby-transformer-sharp` warnings.